### PR TITLE
[Resolves #25] more exact filter for get_parameter

### DIFF
--- a/awsparams/awsparams.py
+++ b/awsparams/awsparams.py
@@ -47,7 +47,9 @@ def get_parameter_value(name, decryption=False, profile=None):
 
 def get_parameter(name, profile=None, values=False, decryption=False):
     ssm = connect_ssm(profile)
-    _params = ssm.describe_parameters(Filters=[{'Key': 'Name', 'Values': [name]}])['Parameters']
+    _params = ssm.describe_parameters(ParameterFilters=[{'Key': 'Name',
+                                                         'Option': 'Equals',
+                                                         'Values': [name]}])['Parameters']
     assert len(_params) == 1
     result = build_param_result(_params[0], profile, values, decryption)
     if result['Name'] != name:


### PR DESCRIPTION
ssm.describe_parameters in get_parameters function expects only
one item back.  However when there are multiple similar keys
in SSM the filter is not exact enough.

```
For example:
  Assume existing params in SSM:
       /bridge/bridgepf/SecretA
       /bridge/bridgepf/SecretB
       /bridge/bridgepf/SecretC

  running the following command will fail:
       awsparams cp /bridge/bridgepf/SecretA /newbridge/SecretA
```
It fails because ssm.describe_parameters will return SecretA,
SecretB, and SecretC.  We need a more exact filter.