### PR TITLE
feat: add flag for formatting output as a list of environment values

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ ls with values and decryption: `awsparams ls --with-decryption`
 
 ls by prefix: `awsparams ls appname.prd`
 
+ls with values, formatted as an environment variable string: `awsparams ls -v --env-format <prefix>` or `awsparams ls -v -f <prefix>`
+> *`--env-format`/`-f` is used for easy quickly pasting into run configurations in IDE's*
+
 ## new usage
 
 new interactively: `awsparams new`

--- a/awsparams/cli.py
+++ b/awsparams/cli.py
@@ -34,12 +34,13 @@ def main():
 @click.option("--profile", type=click.STRING, help="profile to run with")
 @click.option("--region", type=click.STRING, help="optional region to use")
 @click.option("-v", "--values", is_flag=True, help="display values")
+@click.option("-f", "--env-format", is_flag=True, help="format as a list of env vars (used with -v)")
 @click.option(
     "--decryption/--no-decryption",
     help="by default display decrypted values",
     default=True,
 )
-def ls(prefix="", profile="", region="", values=False, decryption=True):
+def ls(prefix="", profile="", region="", values=False, env_format=False, decryption=True):
     """
     List Paramters, optional matching a specific prefix
     """
@@ -50,7 +51,16 @@ def ls(prefix="", profile="", region="", values=False, decryption=True):
         prefix=prefix, values=values, decryption=decryption, trim_name=False
     ):
         if values:
-            click.echo(f"{parm.Name}: {parm.Value}")
+            if env_format:
+                short_param = parm.Name.replace(prefix, "")
+                # most of the time users will not want the leading period (left after the prefix)
+                # However, don't do this always.
+                # If a full prefix is not provided, this will cause an error.
+                if short_param[0] == ".":
+                    short_param = short_param[1:]
+                click.echo(f"{short_param}={parm.Value};")
+            else:
+                click.echo(f"{parm.Name}: {parm.Value}")
         else:
             click.echo(parm.Name)
 

--- a/awsparams/cli.py
+++ b/awsparams/cli.py
@@ -53,9 +53,8 @@ def ls(prefix="", profile="", region="", values=False, env_format=False, decrypt
         if values:
             if env_format:
                 short_param = parm.Name.replace(prefix, "")
-                # most of the time users will not want the leading period (left after the prefix)
-                # However, don't do this always.
-                # If a full prefix is not provided, this will cause an error.
+                # Users will not want the leading period that would remain if only the prefix is trimmed
+                # If an incomplete prefix is used, the first character may not be a period, so check first
                 if short_param[0] == ".":
                     short_param = short_param[1:]
                 click.echo(f"{short_param}={parm.Value};")

--- a/docs/CLI/cli.rst
+++ b/docs/CLI/cli.rst
@@ -38,6 +38,9 @@ ls with values and decryption: ``awsparams ls --with-decryption``
 
 ls by prefix: ``awsparams ls appname.prd``
 
+ls with values, formatted as an environment variable string: ``awsparams ls -v --env-format <prefix>`` or ``awsparams ls -v -f <prefix>``
+*`--env-format`/`-f` is used for easy quickly pasting into run configurations in IDE's*
+
 new usage
 ---------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "awsparams"
-version = "1.3.0"
+version = "1.4.0"
 description = "A simple CLI and Library for adding/removing/renaming/copying AWS Param Store Parameters"
 authors = ["Nate Peterson <ndpete@gmail.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
My coworkers and I use this tool for quickly fetching a relevant list of parameters for a given application in a given AWS account. We need to quickly create run configurations to test different applications without having to manually go to the AWS console to copy and format each parameter individually. 

This tool already speeds up the work but still requires us to do some tweaking of the format to make it work for our needs. 

Adding this optional flag allows us to use this tool to facilitate this additional use case for this app.

Adding this flag is not a breaking change. It is an optional flag, and by default it is set to false, so no changes will occur if users continue to use this app as they have done in the past, even when they update to this version.

Users desiring this added feature will be able to use the feature by simply using the `--env-format` or `-f` flag in conjunction with their normal usage of `ls -v <prefix>`, so the final command can be as simple as something like this: `awsparams ls -vf <prefix>`.

