### PR TITLE
Improve format options

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,18 @@ ls with values and decryption: `awsparams ls --with-decryption`
 
 ls by prefix: `awsparams ls appname.prd`
 
-ls with values, formatted as an environment variable string: `awsparams ls -v --env-format <prefix>` or `awsparams ls -v -f <prefix>`
-> *`--env-format`/`-f` is used for easy quickly pasting into run configurations in IDE's*
+ls with values, formatted for using in a Jetbrains run configuration: `awsparams ls -r <prefix>`
+or `awsparams ls --jetbrains-run-config <prefix>`
+
+ls with values, formatted for using in a `.env` file: `awsparams ls -e <prefix>`
+or `awsparams ls --dot-env <prefix>`
+
+ls with values, formatted for using in a `.tfvars` file: `awsparams ls -t <prefix>`
+or `awsparams ls --tfvars <prefix>`
+
+For the above two options, add the `-q` or `--esc-quotes` flag for adding `\` in front of any quotation marks in
+the values, such as in stringify-ed JSON objects. Most `.env` file parsers don't require this, but `.tfvars`
+probably does.
 
 ## new usage
 

--- a/awsparams/cli.py
+++ b/awsparams/cli.py
@@ -37,7 +37,7 @@ def main():
 @click.option("-e", "--env-vars", is_flag=True, help="format list for a .env file")
 @click.option("-t", "--tfvars", is_flag=True, help="format list for a .tfvars file")
 @click.option("-r", "--run-config", is_flag=True, help="format list for a Jetbrains run configuration")
-@click.option("-q", "--esc-quotes", is_flag=True, help="Escape quotes (for --env-vars or --tfvars)")
+@click.option("-q", "--esc-quotes", is_flag=True, help="Escape quotes in values (for --env-vars or --tfvars)")
 @click.option(
     "--decryption/--no-decryption",
     help="by default display decrypted values",
@@ -46,9 +46,6 @@ def main():
 def ls(prefix="", profile="", region="", values=False, run_config=False, env_vars=False, tfvars=False, esc_quotes=False, decryption=True):
     """
     List Parameters, optionally matching a specific prefix
-    run_config - print out separated by '=' and ended with ';'
-    env_vars - print out separated by '=', values wrapped in quotes
-    tfvars - print out separated by ' = ', values wrapped in quotes
     """
     aws_params = AWSParams(profile, region)
     if run_config or env_vars or tfvars:  # all of these options should also fetch the values
@@ -74,6 +71,11 @@ def ls(prefix="", profile="", region="", values=False, run_config=False, env_var
                     name.insert(0, param_parts[i])
                 # reconstruct the param name
                 name = '/'.join(name)
+                """
+                run_config - print out separated by '=' and ended with ';'
+                env_vars - print out separated by '=', values wrapped in quotes
+                tfvars - print out separated by ' = ', values wrapped in quotes
+                """
                 if env_vars:
                     click.echo(f"{name}=\"{escape_quotes(parm.Value) if esc_quotes else parm.Value}\"")
                 elif tfvars:

--- a/awsparams/cli.py
+++ b/awsparams/cli.py
@@ -45,7 +45,10 @@ def main():
 )
 def ls(prefix="", profile="", region="", values=False, run_config=False, env_vars=False, tfvars=False, esc_quotes=False, decryption=True):
     """
-    List Paramters, optional matching a specific prefix
+    List Parameters, optionally matching a specific prefix
+    run_config - print out separated by '=' and ended with ';'
+    env_vars - print out separated by '=', values wrapped in quotes
+    tfvars - print out separated by ' = ', values wrapped in quotes
     """
     aws_params = AWSParams(profile, region)
     if run_config or env_vars or tfvars:  # all of these options should also fetch the values
@@ -53,7 +56,7 @@ def ls(prefix="", profile="", region="", values=False, run_config=False, env_var
     if not values:
         decryption = False
     for parm in aws_params.get_all_parameters(
-        prefix=prefix, values=values, decryption=decryption, trim_name=False
+            prefix=prefix, values=values, decryption=decryption, trim_name=False
     ):
         if values:
             if run_config or env_vars or tfvars:
@@ -112,15 +115,15 @@ def escape_quotes(string):
     "--key", type=click.STRING, default="", help="kms key to use for new copy"
 )
 def cp(
-    src,
-    dst,
-    src_profile,
-    src_region,
-    dst_profile,
-    dst_region,
-    prefix=False,
-    overwrite=False,
-    key="",
+        src,
+        dst,
+        src_profile,
+        src_region,
+        dst_profile,
+        dst_region,
+        prefix=False,
+        overwrite=False,
+        key="",
 ):
     """
     Copy a parameter, optionally across accounts
@@ -175,7 +178,7 @@ def mv(ctx, src, dst, prefix=False, profile="", region=""):
     """
     if prefix:
         if ctx.invoke(
-            cp, src=src, dst=dst, src_profile=profile, prefix=prefix, src_region=region
+                cp, src=src, dst=dst, src_profile=profile, prefix=prefix, src_region=region
         ):
             ctx.invoke(
                 rm, src=src, force=True, prefix=True, profile=profile, region=region
@@ -236,14 +239,14 @@ def rm(src, force=False, prefix=False, profile="", region=""):
 @click.option("--region", type=click.STRING, help="alternative region to be used")
 @click.option("--overwrite", is_flag=True, help="overwrite exisiting parameters")
 def new(
-    name=None,
-    value=None,
-    param_type="String",
-    key="",
-    description="",
-    profile="",
-    region="",
-    overwrite=False,
+        name=None,
+        value=None,
+        param_type="String",
+        key="",
+        description="",
+        profile="",
+        region="",
+        overwrite=False,
 ):
     """
     Create a new parameter

--- a/awsparams/cli.py
+++ b/awsparams/cli.py
@@ -34,35 +34,63 @@ def main():
 @click.option("--profile", type=click.STRING, help="profile to run with")
 @click.option("--region", type=click.STRING, help="optional region to use")
 @click.option("-v", "--values", is_flag=True, help="display values")
-@click.option("-f", "--env-format", is_flag=True, help="format as a list of env vars (used with -v)")
+@click.option("-e", "--env-vars", is_flag=True, help="format list for a .env file")
+@click.option("-t", "--tfvars", is_flag=True, help="format list for a .tfvars file")
+@click.option("-r", "--run-config", is_flag=True, help="format list for a Jetbrains run configuration")
+@click.option("-q", "--esc-quotes", is_flag=True, help="Escape quotes (for --env-vars or --tfvars)")
 @click.option(
     "--decryption/--no-decryption",
     help="by default display decrypted values",
     default=True,
 )
-def ls(prefix="", profile="", region="", values=False, env_format=False, decryption=True):
+def ls(prefix="", profile="", region="", values=False, run_config=False, env_vars=False, tfvars=False, esc_quotes=False, decryption=True):
     """
     List Paramters, optional matching a specific prefix
     """
     aws_params = AWSParams(profile, region)
+    if run_config or env_vars or tfvars:  # all of these options should also fetch the values
+        values = True
     if not values:
         decryption = False
     for parm in aws_params.get_all_parameters(
         prefix=prefix, values=values, decryption=decryption, trim_name=False
     ):
         if values:
-            if env_format:
-                short_param = parm.Name.replace(prefix, "")
-                # Sometimes leftover delimiters remain at the beginning of the string after this step
-                # This loop removes those delimiters so that the variables are formatted in a useful manner.
-                delimiters = ['.', '\\', '/']
-                while delimiters.count(short_param[0]) != 0:
-                    short_param = short_param[1:]
-                click.echo(f"{short_param}={parm.Value};")
+            if run_config or env_vars or tfvars:
+                param_parts = parm.Name.split('/')
+                prefix_parts = prefix.split('/')
+                # remove any duplicate, leading, or trailing delimiters from both lists
+                for arr in [param_parts, prefix_parts]:
+                    for part in arr:
+                        if part == '':
+                            arr.remove(part)
+                name = []
+                # 'subtract' the prefix from the name by starting from the rightmost element
+                #  and appending elements leftwards until you reach the prefix
+                for i in range(len(param_parts) - 1, len(prefix_parts) - 1, -1):
+                    name.insert(0, param_parts[i])
+                # reconstruct the param name
+                name = '/'.join(name)
+                if env_vars:
+                    click.echo(f"{name}=\"{escape_quotes(parm.Value) if esc_quotes else parm.Value}\"")
+                elif tfvars:
+                    click.echo(f"{name} = \"{escape_quotes(parm.Value) if esc_quotes else parm.Value}\"")
+                elif run_config:
+                    click.echo(f"{name}={parm.Value};")
             else:
                 click.echo(f"{parm.Name}: {parm.Value}")
         else:
             click.echo(parm.Name)
+
+
+def escape_quotes(string):
+    newstr = ''
+    for c in string:
+        if c == '"':
+            newstr += '\\"'
+        else:
+            newstr += c
+    return newstr
 
 
 @main.command("cp")

--- a/awsparams/cli.py
+++ b/awsparams/cli.py
@@ -34,9 +34,9 @@ def main():
 @click.option("--profile", type=click.STRING, help="profile to run with")
 @click.option("--region", type=click.STRING, help="optional region to use")
 @click.option("-v", "--values", is_flag=True, help="display values")
-@click.option("-e", "--env-vars", is_flag=True, help="format list for a .env file")
+@click.option("-e", "--dot-env", is_flag=True, help="format list for a .env file")
 @click.option("-t", "--tfvars", is_flag=True, help="format list for a .tfvars file")
-@click.option("-r", "--run-config", is_flag=True, help="format list for a Jetbrains run configuration")
+@click.option("-r", "--jetbrains-run-config", is_flag=True, help="format list for a Jetbrains run configuration")
 @click.option("-q", "--esc-quotes", is_flag=True, help="Escape quotes in values (for --env-vars or --tfvars)")
 @click.option(
     "--decryption/--no-decryption",

--- a/docs/CLI/cli.rst
+++ b/docs/CLI/cli.rst
@@ -39,10 +39,10 @@ ls with values and decryption: ``awsparams ls --with-decryption``
 ls by prefix: ``awsparams ls appname.prd``
 
 ls with values, formatted for using in a Jetbrains run configuration: ``awsparams ls -r <prefix>``
-or ``awsparams ls --run-config <prefix>``
+or ``awsparams ls --jetbrains-run-config <prefix>``
 
 ls with values, formatted for using in a ``.env`` file: ``awsparams ls -e <prefix>``
-or ``awsparams ls --env-vars <prefix>``
+or ``awsparams ls --dot-env <prefix>``
 
 ls with values, formatted for using in a ``.tfvars`` file: ``awsparams ls -t <prefix>``
 or ``awsparams ls --tfvars <prefix>``

--- a/docs/CLI/cli.rst
+++ b/docs/CLI/cli.rst
@@ -16,7 +16,7 @@ Usage can be referenced by running ``awsparams --help`` or
 
    Commands:
    cp   Copy a parameter, optionally across accounts
-   ls   List Paramters, optional matching a specific...
+   ls   List Paramters, optional matching a specific prefix
    mv   Move or rename a parameter
    new  Create a new parameter
    rm   Remove/Delete a parameter
@@ -38,8 +38,18 @@ ls with values and decryption: ``awsparams ls --with-decryption``
 
 ls by prefix: ``awsparams ls appname.prd``
 
-ls with values, formatted as an environment variable string: ``awsparams ls -v --env-format <prefix>`` or ``awsparams ls -v -f <prefix>``
-*`--env-format`/`-f` is used for easy quickly pasting into run configurations in IDE's*
+ls with values, formatted for using in a Jetbrains run configuration: ``awsparams ls -r <prefix>``
+or ``awsparams ls --run-config <prefix>``
+
+ls with values, formatted for using in a ``.env`` file: ``awsparams ls -e <prefix>``
+or ``awsparams ls --env-vars <prefix>``
+
+ls with values, formatted for using in a ``.tfvars`` file: ``awsparams ls -t <prefix>``
+or ``awsparams ls --tfvars <prefix>``
+
+For the above two options, add the ``-q`` or ``--esc-quotes`` flag for adding ``\`` in front of any quotation marks in
+the values, such as in stringify-ed JSON objects. Most ``.env`` file parsers don't require this, but ``.tfvars``
+probably does.
 
 new usage
 ---------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "awsparams"
-version = "1.4.1"
+version = "1.5.0"
 description = "A simple CLI and Library for adding/removing/renaming/copying AWS Param Store Parameters"
 authors = ["Nate Peterson <ndpete@gmail.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
We use the `ls` command of this tool a lot in our day-to-day work and a while back I added an option to be able to print out the variables in such a way that makes it easy to copy-paste into a Jetbrains run configuration. I did it pretty sloppily and there were lots of bugs, so this improves on that. It also adds two additional options for formatting in a `.env` file or a `.tfvars` file style, which are also common use cases for us. These features will save a lot of time for us but they won't break functionality for anyone using this tool as it originally functioned.
I used to have push-access to this repo but I no longer do.